### PR TITLE
Add styling to demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,20 +3,19 @@
 <head>
     <meta charset="utf-8">
     <title>pascaljs</title>
-    <style>
-        #editor {
-                width: 640px;height:480px;
-            }
-    </style>
+    <link rel="stylesheet" href="main.css"></link>
+    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
     <script src="build/bundle.js"></script>
 </head>
 
 <body>
-<h1>pascaljs</h1>
-  <p>Pascal compiler in js that emits js. Can be used
-  to compile and/or run pascal programs in the browser.</p>
+  <div class="title-description-container">
+    <h1 class="site-title">pascaljs</h1>
+    <p class="site-description">Pascal compiler in js that emits js. Can be used
+    to compile and/or run pascal programs in the browser.</p>
+  </div>
 
-  <div>
+  <div class="editor">
     <div id="editor">program x;
 begin
   WriteLn('Hello World!');

--- a/demo/main.css
+++ b/demo/main.css
@@ -1,0 +1,41 @@
+#editor {
+  width: 640px;height:480px;
+}
+
+body {
+  font-family: 'Montserrat', sans-serif;
+  background-color: #477890;
+  color: white;
+}
+
+.title-description-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.site-description {
+  text-align: center;
+  width: 600px;
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.editor button {
+  margin-top: 10px;
+  color: white;
+  background: rgba(0,0,0,0);
+  border: solid 3px white;
+  height: 40px;
+  width: 70px;
+  font-size: 1em;
+}
+
+.editor button:hover {
+  border-color: #D1E6FC;
+  color: #D1E6FC;
+}


### PR DESCRIPTION
All content is aligned to center. Button and font family were changed to san serif to match the font style in the editor.

This issue resolves #26.